### PR TITLE
Preventing an error when there were no legal tyres

### DIFF
--- a/frontend/app/controllers.js
+++ b/frontend/app/controllers.js
@@ -193,7 +193,7 @@ angular.module('acServerManager')
 			try {
 				$scope.selectedCars = data.CARS.split(';');
 				$scope.selectedTracks = data.TRACK; //TODO: Multi-track
-				$scope.selectedTyres = data.LEGAL_TYRES.split(';');
+				$scope.selectedTyres = typeof(data.LEGAL_TYRES) != "undefined" ? data.LEGAL_TYRES.split(';') : [];
 			
 				data.LOOP_MODE = data.LOOP_MODE == 1;
 				data.LOCKED_ENTRY_LIST = data.LOCKED_ENTRY_LIST == 1;


### PR DESCRIPTION
Previously I was an error on the server configuration page because I did not have any legal tyres in my configuration. This then prevented me from saving the page and changing the configuration.

This check for undefined prevents the error.